### PR TITLE
Update hide-popover script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A userscript for ChatGPT Codex tasks that lets you queue prompts and run them sequentially. Clicking the injected **Code++** button stores the current prompt in a persistent list displayed as draggable toast cards. Items can be reordered, removed and will automatically execute one after another.
 
+This repo also includes a tiny helper script, **Hide Popover via CSS**, that removes the new "UI tip" popover OpenAI shows when you hold either <kbd>Ctrl</kbd> key. The tip is distracting while typing, so the script injects CSS that hides it before the page fully loads.
+
 |                   |                                                      |
 |-------------------|------------------------------------------------------|
 | **Userscript name** | `Codex task – Code++ queue helper` |
@@ -34,8 +36,9 @@ A userscript for ChatGPT Codex tasks that lets you queue prompts and run them se
 1. Install a userscript manager:
    - Chrome/Edge/Brave: [Tampermonkey](https://www.tampermonkey.net/)
    - Firefox: [Violentmonkey](https://violentmonkey.github.io/) or Tampermonkey
-2. Open [`codeplus-queue-helper.user.js`](./codeplus-queue-helper.user.js) and click **Raw** to install.
-3. Visit a Codex task page. A new **Code++** button appears next to the stop button.
+2. Open [`codeplus-queue-helper.user.js`](./codeplus-queue-helper.user.js) and click **Raw** to install the queue helper.
+3. Open [`hide-popover.user.js`](./hide-popover.user.js) and click **Raw** if you want to disable the new Ctrl popover.
+4. Visit a Codex task page. A new **Code++** button appears next to the stop button.
 
 ## Usage
 

--- a/codeplus-queue-helper.user.js
+++ b/codeplus-queue-helper.user.js
@@ -2,6 +2,7 @@
 // @name         Codex task – Code++ queue helper
 // @namespace    https://chatgpt.com/
 // @version      0.1.24
+// @author       Arman Yeghiazaryan - @otanim
 // @description  Adds a “Code++” button to Codex task pages, storing each prompt in a persistent queue and displaying them as numbered toasts (375 px min‑width) that you can drag‑resize, reorder (up/down) or delete. Inline SVG icons keep it CSP‑safe, and the queue auto‑executes tasks while marking toasts as processing or done.
 // @match        https://chatgpt.com/codex/tasks/task*
 // @grant        none

--- a/hide-popover.user.js
+++ b/hide-popover.user.js
@@ -1,0 +1,24 @@
+// ==UserScript==
+// @name         Hide Popover via CSS
+// @namespace    http://tampermonkey.net/
+// @version      0.1
+// @author       Arman Yeghiazaryan - @otanim
+// @description  Hide the script‑adjacent .popover.select-none by injecting CSS
+// @match        https://chatgpt.com/*
+// @run-at       document-start
+// @grant        none
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    // inject a CSS rule so that any .popover.select-none immediately
+    // following a <script> tag is hidden by default
+    const style = document.createElement('style');
+    style.textContent = `
+        .popover.select-none {
+            display: none !important;
+        }
+    `;
+    document.head.appendChild(style);
+})();


### PR DESCRIPTION
## Summary
- hide all Ctrl tip popovers via CSS

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68869ae30d8c832d9cd9c7a333bcfff4